### PR TITLE
v1.11.3 template_fusion_plugin - VERSION RELEASE - CHANGELOG.rst formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see geoips/CHANGELOG_TEMPLATE.rst for instructions on updating
-CHANGELOG appropriately with each PR.
+Please see
+``$GEOIPS_PACKAGES_DIR/geoips/CHANGELOG_TEMPLATE.rst``
+for instructions on updating CHANGELOG appropriately
+with each PR.
 
-Release notes for previous/upcoming versions can be found in
-docs/source/releases, for reference.
+The release note that is currently, actively being updated in
+all geoips plugin repositories can be found in the file
+``$GEOIPS_PACKAGES_DIR/geoips/update_this_release_note``.
+
+You can either:
+
+* update the appropriate release note in this repo directly.
+* or update this ``CHANGELOG.rst`` file with your release
+  notes, for simplicity (your notes will be moved to the
+  appropriate release note in ``docs/source/releases``
+  during the PR process)


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#346
required to close NRLMMD-GEOIPS/geoips#341

# Reviewer Instructions
* Please confirm merge is into 'main' branch from 'v1.11.3-release'
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates.

# Summary
Changes for version 1.11.3 update on repo template_fusion_plugin.
See release notes in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#346 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#341 for dev updates included in this update.

# Testing Instructions
<!-- Remove this section if this is a repo without tests-->
Install GEOIPS and clone v1.11.3-release branch for:
* template_fusion_plugin
<!-- include additional repositories that must also be updated for tests to pass -->

Tests should return 0:
# The 'full_test.sh' will test ALL repos and test data available on github.com
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_test.sh
# Potentially only a subset of the 'test_all.sh' tests in each repo will work:
$GEOIPS_PACKAGES_DIR/template_fusion_plugin/tests/test_all.sh

# Output
<!-- Remove this section if this is a repo without outputs -->
<!-- Copy/paste appropriate output here if you installed and ran updates on open source -->

# Post Merge Steps
Once this PR has been merged, v1.11.3 will be tagged/released on the template_fusion_plugin main branch.